### PR TITLE
Allow puppetlabs-stdlib 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 8.6.0 < 9.0.0"
+      "version_requirement": ">= 8.6.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-augeas_core",


### PR DESCRIPTION
Hey @rehanone, I wanted to setup a samba server on my linux machine with puppet, but found that my current version of puppetlabs-stdlib (9.4.1) is incompatible with rehanone-samba's February release.

Changelog: https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/CHANGELOG.md#v900---2023-05-30