### PR TITLE
Add 'samba::additional_config' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ This module is designed to be as clean and compliant with latest puppet code gui
       local_master         => 'yes',
       preferred_master     => 'yes',
       map_to_guest         => 'Bad User',
+      additional_config    => {
+        server_multi_channel_support => 'yes'
+      },
       shares => {
         'homes' => {
           comment    => 'Home Directories',
@@ -102,6 +105,8 @@ samba::local_master: 'yes'
 samba::preferred_master: 'yes'
 samba::map_to_guest: 'Bad User'
 samba::firewall_manage: true
+additional_config:
+  server_multi_channel_support: 'yes'
 samba::shares:
   'homes':
     comment: 'Home Directories'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,7 @@ The following parameters are available in the `samba` class:
 * [`dedicated_keytab_file`](#-samba--dedicated_keytab_file)
 * [`obey_pam_restrictions`](#-samba--obey_pam_restrictions)
 * [`shares`](#-samba--shares)
+* [`additional_config`](#-samba--additional_config)
 * [`idmap_config`](#-samba--idmap_config)
 
 ##### <a name="-samba--packages"></a>`packages`
@@ -434,6 +435,14 @@ Default value: `false`
 Data type: `Hash`
 
 A hash of share names, their path(s) and other parameters.
+
+Default value: `{}`
+
+##### <a name="-samba--additional_config"></a>`additional_config`
+
+Data type: `Variant[Undef, Hash]`
+
+Additional configuration options to be added to the server smb.conf file.
 
 Default value: `{}`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,13 @@ class samba::config () inherits samba {
     'obey pam restrictions':    value => $samba::obey_pam_restrictions;
   }
 
+  $samba::additional_config.each | $option, $value | {
+    $option_with_spaces = regsubst($option, /_/, ' ', 'G')
+    samba::option { $option_with_spaces:
+      value => $value,
+    }
+  }
+
   $samba::idmap_config.each | $idmap_domain, $idmap_options | {
     $idmap_options.each | $idmap_option, $idmap_value | {
       samba::option { "idmap config ${idmap_domain} : ${idmap_option}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@
 #    This integer value controls what level Samba advertises itself as for browse elections.
 #
 # @param wins_support
-#    This boolean controls if the nmbd(8) process in Samba will act as a WINS server. 
+#    This boolean controls if the nmbd(8) process in Samba will act as a WINS server.
 #
 # @param wins_server
 #    This specifies the IP address (or DNS name: IP address for preference) of the WINS server that nmbd(8) should register with.
@@ -142,6 +142,9 @@
 # @param shares
 #    A hash of share names, their path(s) and other parameters.
 #
+# @param additional_config
+#    Additional configuration options to be added to the server smb.conf file.
+#
 # @param idmap_config
 #    The mapping between Windows SIDs and Unix user and group IDs.
 #
@@ -203,6 +206,7 @@ class samba (
   Variant[Undef, String] $kerberos_method = 'default',
   Variant[Undef, String] $dedicated_keytab_file = undef,
   Variant[Undef, Boolean] $obey_pam_restrictions = false,
+  Variant[Undef, Hash] $additional_config = {},
   Variant[Undef, Hash] $idmap_config = {},
   Hash $shares = {},
 ) {

--- a/spec/classes/samba_spec.rb
+++ b/spec/classes/samba_spec.rb
@@ -57,6 +57,10 @@ describe 'samba' do
         let(:params) do
           {
             netbios_name: 'foo',
+            additional_config: { server_multi_channel_support: 'yes',
+                                 aio_read_size: 1,
+                                 aio_write_size: 1,
+                                 min_receivefile_size: 16_384 },
             idmap_config: { '*' => { backend: 'tbd', range: '400-999' },
                            'AD' => { unix_primary_group: 'Yes', unix_nss_info: 'Yes', schema_mode: 'rfc2307', range: '1000-2147483647', backend: 'ad' } }
           }
@@ -95,6 +99,10 @@ describe 'samba' do
           is_expected.to contain_samba__option('kerberos method').with_value('default')
           is_expected.to contain_samba__option('dedicated keytab file').with_value(nil)
           is_expected.to contain_samba__option('obey pam restrictions').with_value(false)
+          is_expected.to contain_samba__option('server multi channel support').with_value('yes')
+          is_expected.to contain_samba__option('aio read size').with_value(1)
+          is_expected.to contain_samba__option('aio write size').with_value(1)
+          is_expected.to contain_samba__option('min receivefile size').with_value(16_384)
           is_expected.to contain_samba__option('idmap config * : backend').with_value('tbd')
           is_expected.to contain_samba__option('idmap config * : range').with_value('400-999')
           is_expected.to contain_samba__option('idmap config AD : unix_primary_group').with_value('Yes')
@@ -105,7 +113,7 @@ describe 'samba' do
         }
 
         it {
-          is_expected.to have_samba__option_resource_count(39)
+          is_expected.to have_samba__option_resource_count(43)
         }
       end
 


### PR DESCRIPTION
Hey @rehanone, another one for you to consider. There are a bunch of unsupported server configs, so I wonder if we could add a very flexible system for allowing the user to specify them.

This allows the user of the module to specify arbitrary server configuration options. For example, in hiera:

    samba::additional_config:
      server_multi_channel_support: true
      aio_read_size: 1
      aio_write_size: 1
      min_receivefile_size: 16384

This would write the following to `smb.conf`:

    [global]
        server multi channel support = yes
        aio read size = 1
        aio write size = 1
        min receivefile size = 16384

Fixes https://github.com/rehanone/puppet-samba/issues/31.