### PR TITLE
Add hosts_allow , host_deny, inherit_acl and host msdfs at the share level

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -188,7 +188,7 @@ Data type: `Variant[Undef, String]`
 
 This sets the NetBIOS name by which a Samba server is known.
 
-Default value: `'%{facts.hostname}'`
+Default value: `'%{facts.networking.hostname}'`
 
 ##### <a name="-samba--domain_master"></a>`domain_master`
 
@@ -584,6 +584,10 @@ The following parameters are available in the `samba::share` defined type:
 * [`writable`](#-samba--share--writable)
 * [`available`](#-samba--share--available)
 * [`browseable`](#-samba--share--browseable)
+* [`inherit_acl`](#-samba--share--inherit_acl)
+* [`host_msdfs`](#-samba--share--host_msdfs)
+* [`hosts_allow`](#-samba--share--hosts_allow)
+* [`hosts_deny`](#-samba--share--hosts_deny)
 * [`copy`](#-samba--share--copy)
 * [`create_mask`](#-samba--share--create_mask)
 * [`directory_mask`](#-samba--share--directory_mask)
@@ -649,6 +653,38 @@ Default value: `undef`
 Data type: `Optional[Boolean]`
 
 This controls whether this share is seen in the list of available shares in a net view and in the browse list.
+
+Default value: `undef`
+
+##### <a name="-samba--share--inherit_acl"></a>`inherit_acl`
+
+Data type: `Optional[Boolean]`
+
+The inherit acl parameter in Samba controls whether Access Control Lists (ACLs) set on parent directories are automatically inherited by new files and subdirectories created within them.
+
+Default value: `undef`
+
+##### <a name="-samba--share--host_msdfs"></a>`host_msdfs`
+
+Data type: `Optional[Boolean]`
+
+The host msdfs parameter controls whether the Samba server acts as an MSDFS root, facilitating redirection of file shares in a distributed file system.
+
+Default value: `undef`
+
+##### <a name="-samba--share--hosts_allow"></a>`hosts_allow`
+
+Data type: `Optional[Array[String]]`
+
+The hosts allow parameter limit access to these ip-addresses.
+
+Default value: `undef`
+
+##### <a name="-samba--share--hosts_deny"></a>`hosts_deny`
+
+Data type: `Optional[Array[String]]`
+
+The hosts deny parameter deny access to these ip-addresses.
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,7 +175,7 @@ class samba (
   # Main smb.conf options
   Variant[Undef, String] $workgroup    =  'WORKGROUP',
   Variant[Undef, String] $server_string = '%h server (Samba Server Version %v)',
-  Variant[Undef, String] $netbios_name  = '%{facts.hostname}',
+  Variant[Undef, String] $netbios_name  = '%{facts.networking.hostname}',
   Variant[Boolean, String] $domain_master = 'auto',
   Variant[Boolean, String] $preferred_master = 'auto',
   Variant[Undef, Boolean] $local_master = true,

--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -17,6 +17,18 @@
 # @param browseable
 #    This controls whether this share is seen in the list of available shares in a net view and in the browse list.
 #
+# @param inherit_acl
+#    The inherit acl parameter in Samba controls whether Access Control Lists (ACLs) set on parent directories are automatically inherited by new files and subdirectories created within them. 
+#
+# @param host_msdfs
+#    The host msdfs parameter controls whether the Samba server acts as an MSDFS root, facilitating redirection of file shares in a distributed file system.
+#
+# @param hosts_allow
+#    The hosts allow parameter limit access to these ip-addresses.
+#
+# @param hosts_deny
+#    The hosts deny parameter deny access to these ip-addresses.
+#
 # @param copy
 #    This parameter allows you to "clone" service entries. The specified service is simply duplicated under the current service's name.
 #
@@ -104,6 +116,10 @@ define samba::share (
   Optional[Boolean] $writable                 = undef,
   Optional[Boolean] $available                = undef,
   Optional[Boolean] $browseable               = undef,
+  Optional[Boolean] $host_msdfs               = undef,
+  Optional[Boolean] $inherit_acl              = undef,
+  Optional[Array[String]] $hosts_allow        = undef,
+  Optional[Array[String]] $hosts_deny         = undef,
   Optional[String]  $copy                     = undef,
   Optional[String]  $create_mask              = undef,
   Optional[String]  $directory_mask           = undef,
@@ -163,6 +179,10 @@ define samba::share (
       "${title}-writable":             target => $target, key => 'writable', value => $writable;
       "${title}-available":            target => $target, key => 'available', value => $available;
       "${title}-browseable":           target => $target, key => 'browseable', value => $browseable;
+      "${title}-host_msdfs":           target => $target, key => 'host msdfs', value => $host_msdfs;
+      "${title}-inherit_acl":          target => $target, key => 'inherit acl', value => $inherit_acl;
+      "${title}-hosts_allow":          target => $target, key => 'hosts allow', value => $hosts_allow;
+      "${title}-hosts_deny":           target => $target, key => 'hosts deny', value => $hosts_deny;
       "${title}-copy":                 target => $target, key => 'copy', value => $copy;
       "${title}-create mask":          target => $target, key => 'create mask', value => $create_mask;
       "${title}-directory mask":       target => $target, key => 'directory mask', value => $directory_mask;

--- a/spec/defines/share_spec.rb
+++ b/spec/defines/share_spec.rb
@@ -43,7 +43,7 @@ describe 'samba::share' do
         }
 
         it {
-          is_expected.to have_samba__option_resource_count(63)
+          is_expected.to have_samba__option_resource_count(67)
         }
       end
     end


### PR DESCRIPTION
Add inherit_acl and host msdfs at the share level
Fix netbios_name default string https://github.com/rehanone/puppet-samba/issues/55 
Regenerated REFERENCE.md