### PR TITLE
Stop duplicate entries for idmap being created

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,6 +57,10 @@ class samba::config () inherits samba {
       samba::option { "idmap config ${idmap_domain} : ${idmap_option}":
         value => $idmap_value,
       }
+      # Remove any identical entries without spacing:
+      samba::option { "idmap config ${idmap_domain}:${idmap_option}":
+        value => '',
+      }
     }
   }
 


### PR DESCRIPTION
The current code assumes spaces around the idmap colon parameter and leaves duplicate entries if in the original file there were identical idmap parameters (but differing only in their spacing in the parameters).
Incidentally this is true about any parameter used with this module, just a lot harder to fix as this seems to need work in augeas.